### PR TITLE
Inform user that the rocketpool smartnode validator needs manual restarting

### DIFF
--- a/rocketarb.mjs
+++ b/rocketarb.mjs
@@ -677,6 +677,7 @@ else {
         console.log('Bundle successfully included on chain!')
         console.log(`Moving ${options.bundleFile} to bundle.${minipoolAddress}.json`)
         await fs.rename(options.bundleFile, `bundle.${minipoolAddress}.json`)
+	console.log(`You might have to restart the smartnode validator container/process for it to pick up the new validator. Otherwise it might miss attestations and block proposals once it is activated by the beaconchain.`)
         process.exit()
       }
       else {


### PR DESCRIPTION
This avoids people missing attestations once they come live, as it happened to my friend recently.
It's a bad look to have RP validators be activated by the chain and start off missing attestations until the NO notices it.
This message helps to avoid that.
It's pretty easy to falsely think that no manual restart is required, since the rocketpool_node container _does_ pick up the new validator and executes the stake TX. Thus it is surprising (to a noob) that the validator process _does not_.